### PR TITLE
"version" is deprecated

### DIFF
--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -1,5 +1,4 @@
 #ddev-generated
-version: '3.6'
 services:
   cypress:
     image: cypress/included:10.9.0


### PR DESCRIPTION
Remove "version" form docker-compose in line with DDEV "best practises"

See https://docs.docker.com/compose/compose-file/#version-top-level-element