### PR TITLE
⏫ bump Cypress to `12.3.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This recipe integrates a Cypress docker image with your DDEV project.
   - macOS 10.9 and above (Intel or Apple Silicon 64-bit (x64 or arm64))
   - Linux Ubuntu 12.04 and above, Fedora 21 and Debian 8 (x86_64 or Arm 64-bit (x64 or arm64))
   - Windows 7 and above (64-bit only)
+- Interactive mode requires a X11 server running on the host machine.
 
 ## Steps
 
@@ -97,6 +98,14 @@ It is considered best practice to use a [specific image tag](https://github.com/
 Cypress can run into 2 different modes: interactive and runner.
 This recipe includes 2 alias commands to help you use Cypress.
 
+To see Cypress in interactive mode, Cypress forward XVFB messages out of the Cypress container into an X11 server running on the host machine. There are many options depending on your OS. User have reported success with the following:
+
+- Windows 10 / WSL users:
+  - [GWSL](https://opticos.github.io/gwsl/tutorials/manual.html) (via [Microsoft store](ms-windows-store://pdp/?productid=9NL6KD1H33V3))
+  - [VcXsrv](https://sourceforge.net/projects/vcxsrv/) (via [chocolatey](https://community.chocolatey.org/packages/vcxsrv#versionhistory)).
+- Mac users:
+  - [XQuartz](https://www.xquartz.org/). See [Running GUI applications using Docker for Mac](https://sourabhbajaj.com/blog/2017/02/07/gui-applications-docker-mac/).
+
 ### `cypress-open`
 
 To open cypress in "interactive" mode, run the following command:
@@ -146,7 +155,6 @@ Cypress expects a directory strutures containing the tests, plugins and support 
 ### "Unable to open X display."
 
 - This recipe forwards the Cypress GUI via an X11 / X410 server. Please ensure you have this working on your host system.
-- For Windows 10 users, try [GWSL](https://opticos.github.io/gwsl/tutorials/manual.html) (via [Microsoft store](ms-windows-store://pdp/?productid=9NL6KD1H33V3)), or [VcXsrv](https://sourceforge.net/projects/vcxsrv/) (via [chocolatey](https://community.chocolatey.org/packages/vcxsrv#versionhistory))
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,10 @@ This recipe integrates a Cypress docker image with your DDEV project.
   ddev restart
   ```
 
-- Add a `./cypress.json` cypress configuration. Note: DDEV automatically sets the "BaseURL" via the image environmental variables. The `baseURL` setting below will be ignored.
+- Run cypress via `ddev cypress-open` or `ddev cypress-run` (headless).
 
-```json
-{
-    "baseURL": "https://ddev-cypress-demo.ddev.site",
-    "integrationFolder": "./tests/E2E",
-}
-```
-
-- Run cypress via `cypress run` (headless) or `cypress open`.
+It is recommended to run `ddev cypress-open` first to create configuration and support files.
+This addon sets `CYPRESS_baseUrl` to DDEV's primary URL in the `docker-compose.cypress.yaml`.
 
 ### Configure `DISPLAY`
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ This recipe integrates a Cypress docker image with your DDEV project.
 ## Requirements
 
 - DDEV >= 1.19
-- Windows or Linux
-
-NOTE: This uses [cypress/include](https://hub.docker.com/r/cypress/included) which does not have arm64 images and therefore does **not** support M1 Macs.
+- Modern OS
+  - macOS 10.9 and above (Intel or Apple Silicon 64-bit (x64 or arm64))
+  - Linux Ubuntu 12.04 and above, Fedora 21 and Debian 8 (x86_64 or Arm 64-bit (x64 or arm64))
+  - Windows 7 and above (64-bit only)
 
 ## Steps
 
@@ -155,7 +156,6 @@ Cypress expects a directory strutures containing the tests, plugins and support 
 
 ## TODO
 
-- [ ] Add arm64 / mac solution
 - [ ] Add steps for intergrating into Github Actions
 
 **Contributed by [@tyler36](https://github.com/tyler36)**

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To open cypress in "interactive" mode, run the following command:
 ddev cypress-open
 ```
 
-This command also accepts arguments. Refer to the ["#cyress open" documentation](https://docs.cypress.io/guides/guides/command-line#cypress-open) for further details.
+This command also accepts arguments. Refer to the ["#cypress open" documentation](https://docs.cypress.io/guides/guides/command-line#cypress-open) for further details.
 
 Example: To open Cypress in interactive mode, and specify a config file
 
@@ -147,7 +147,7 @@ ddev cypress-run --browser chrome
 
 ### "Could not find a Cypress configuration file, exiting"
 
-Cypress expects a directory strutures containing the tests, plugins and support files.
+Cypress expects a directory structures containing the tests, plugins and support files.
 
 - If the `./cypress` directory does not exist, it will scaffold out these directories, including a default `cypress.json` setting file and example tests when you first run `ddev cypress-open`.
 - Make sure you have a `cypress.json` file in your project root, or use `--config [file]` argument to specify one.
@@ -158,6 +158,6 @@ Cypress expects a directory strutures containing the tests, plugins and support 
 
 ## TODO
 
-- [ ] Add steps for intergrating into Github Actions
+- [ ] Add steps for integrating into Github Actions
 
 **Contributed by [@tyler36](https://github.com/tyler36)**

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 services:
   cypress:
-    image: cypress/included:10.9.0
+    image: cypress/included:12.3.0
     container_name: ddev-${DDEV_SITENAME}-cypress
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 services:
   cypress:
-    image: cypress/included:12.3.0
+    image: cypress/included:12.6.0
     container_name: ddev-${DDEV_SITENAME}-cypress
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -6,7 +6,6 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
-    user: "${DDEV_UID}:${DDEV_GID}"
     networks: [default, ddev_default]
 
     tty: true

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -20,6 +20,8 @@ services:
       - "${DDEV_APPROOT}:/e2e"
       # Mount DDEV to allow commands
       - ".:/mnt/ddev_config"
+      # Allow X11 forwarding
+      - /tmp/.X11-unix:/tmp/.X11-unix
 
     external_links:
       # Resolve links via DDEV router

--- a/install.yaml
+++ b/install.yaml
@@ -4,12 +4,7 @@ name: ddev-cypress
 # Examples would be removing an extraneous docker volume,
 # or doing a sanity check for requirements.
 pre_install_actions:
-- |
-  #ddev-nodisplay
-  if [ "$(arch)" = "arm64" -o "$(arch)" = "aarch64" ]; then 
-    echo "This package does not work on arm64 machines"; 
-    exit 1; 
-  fi
+
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:


### PR DESCRIPTION
This bumps the version os Cypress to `12.3.0`.

The latest version is currently `12.5.1` however, this seems to generate an error:

`EACCES: permission denied, open '/root/.cache/Cypress/12.5.1/binary_state.json`

This also occurs in `12.4.0` flavors, and `12.5.0`. 

This PR may help resolve #19.

Further testing should be done before merging.