### PR TITLE
🛠️ fix permission issue

### DIFF
--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -6,6 +6,7 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
+    user: "${DDEV_UID}:${DDEV_GID}"
     networks: [default, ddev_default]
 
     tty: true


### PR DESCRIPTION
Fix a regression in 413d5c52308e78d8fd144a1cf14d84d72f77b741

Cypress requires root access. Without this PR, a user on the host can not easily delete images or videos Cypress creates when tests fail (Eg. requires sudo)