### PR TITLE
refactor bats test

### DIFF
--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 services:
   cypress:
-    image: cypress/included:12.6.0
+    image: cypress/included:13.11.0
     container_name: ddev-${DDEV_SITENAME}-cypress
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,19 +1,15 @@
 setup() {
   set -eu -o pipefail
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
+  export PROJNAME=test-cypress
   export TESTDIR=~/tmp/test-cypress
   mkdir -p $TESTDIR
-  export PROJNAME=test-cypress
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   mkdir -p "public"
   cp -r "${DIR}/tests/testdata/"* "${TESTDIR}"
   ddev config --project-name=${PROJNAME} --docroot=public
-  ddev start -y >/dev/null
-
-  # Disable DRI3 extension
-  export LIBGL_DRI3_DISABLE=1
 }
 
 health_checks() {
@@ -37,11 +33,11 @@ teardown() {
   health_checks
 }
 
-@test "install from release" {
-  set -eu -o pipefail
-  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get tyler36/ddev-cypress with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get tyler36/ddev-cypress
-  ddev restart >/dev/null
-  health_checks
-}
+# @test "install from release" {
+#   set -eu -o pipefail
+#   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+#   echo "# ddev get tyler36/ddev-cypress with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+#   ddev get tyler36/ddev-cypress
+#   ddev restart >/dev/null
+#   health_checks
+# }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,9 +1,9 @@
 setup() {
   set -eu -o pipefail
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/ddev-cypress
+  export TESTDIR=~/tmp/test-cypress
   mkdir -p $TESTDIR
-  export PROJNAME=ddev-cypress
+  export PROJNAME=test-cypress
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -33,11 +33,11 @@ teardown() {
   health_checks
 }
 
-# @test "install from release" {
-#   set -eu -o pipefail
-#   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-#   echo "# ddev get tyler36/ddev-cypress with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-#   ddev get tyler36/ddev-cypress
-#   ddev restart >/dev/null
-#   health_checks
-# }
+@test "install from release" {
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  echo "# ddev get tyler36/ddev-cypress with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get tyler36/ddev-cypress
+  ddev restart >/dev/null
+  health_checks
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -7,7 +7,7 @@ setup() {
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  mkdir "public"
+  mkdir -p "public"
   cp -r "${DIR}/tests/testdata/"* "${TESTDIR}"
   ddev config --project-name=${PROJNAME} --docroot=public
   ddev start -y >/dev/null

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -11,6 +11,9 @@ setup() {
   cp -r "${DIR}/tests/testdata/"* "${TESTDIR}"
   ddev config --project-name=${PROJNAME} --docroot=public
   ddev start -y >/dev/null
+
+  # Disable DRI3 extension
+  export LIBGL_DRI3_DISABLE=1
 }
 
 health_checks() {

--- a/tests/testdata/cypress.config.js
+++ b/tests/testdata/cypress.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+};

--- a/tests/testdata/cypress.config.js
+++ b/tests/testdata/cypress.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   e2e: {
+    baseUrl: process.env.DDEV_PRIMARY_URL,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/tests/testdata/cypress/e2e/test.cy.js
+++ b/tests/testdata/cypress/e2e/test.cy.js
@@ -1,0 +1,6 @@
+describe('Example test', () => {
+  it('Can read the site', () => {
+    cy.visit('https://ddev-cypress.ddev.site')
+    cy.contains('this is a test')
+  })
+})

--- a/tests/testdata/cypress/e2e/test.cy.js
+++ b/tests/testdata/cypress/e2e/test.cy.js
@@ -1,6 +1,6 @@
 describe('Example test', () => {
   it('Can read the site', () => {
-    cy.visit('https://ddev-cypress.ddev.site')
+    cy.visit('/')
     cy.contains('this is a test')
   })
 })

--- a/tests/testdata/cypress/support/e2e.js
+++ b/tests/testdata/cypress/support/e2e.js
@@ -1,0 +1,14 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************

--- a/tests/testdata/public/index.html
+++ b/tests/testdata/public/index.html
@@ -1,0 +1,1 @@
+<html><head></head><body>this is a test</body>


### PR DESCRIPTION
This PR updates the addon's main tests.

Previously, we simple checked if Cypress could report its version number (although we didn't care what it was).

This PR refactors the test to:
- Serve a HTML page via DDEV
- Run cypress to confirm it can load and read the page.

This acts as a "real" test by actually using Cypress and supplying an example use that others can follow.

