### PR TITLE
Set fallback for DISPLAY

### DIFF
--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -13,7 +13,7 @@ services:
 
     environment:
       - CYPRESS_baseUrl=${DDEV_PRIMARY_URL}
-      - DISPLAY
+      - DISPLAY=${DISPLAY:-host.docker.internal:0}
 
     volumes:
       # Mount the project root to Cypress's project point


### PR DESCRIPTION
This PR set a fallback for the DISPLAY environmental variable.

If not present, it will fallback to the docker host IP address.