### PR TITLE
bump cypress image

### DIFF
--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 services:
   cypress:
-    image: cypress/included:13.15.2
+    image: cypress/included:13.16.0
     container_name: ddev-${DDEV_SITENAME}-cypress
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
This PR updates the `cypress/included` image to `13.16.0`, the current latest.