### PR TITLE
fix: add support for multiple hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Installing Cypress with favorite package manager works great locally. However, m
   ddev restart
   ```
 
+  > [!NOTE]
+  > If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get tyler36/ddev-cypress`
+
 - Run cypress via `ddev cypress-open` or `ddev cypress-run` (headless).
 
 We recommend running `ddev cypress-open` first to create configuration and support files.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Installing Cypress with favorite package manager works great locally. However, m
   ddev restart
   ```
 
-  > [!NOTE]
-  > If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get tyler36/ddev-cypress`
+> [!NOTE]
+> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get tyler36/ddev-cypress`
 
 - Run cypress via `ddev cypress-open` or `ddev cypress-run` (headless).
 

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -24,9 +24,5 @@ services:
       # Allow X11 forwarding
       - /tmp/.X11-unix:/tmp/.X11-unix
 
-    external_links:
-      # Resolve links via DDEV router
-      - "ddev-router:${DDEV_HOSTNAME}"
-
     entrypoint: /bin/bash
     working_dir: /e2e

--- a/install.yaml
+++ b/install.yaml
@@ -19,12 +19,14 @@ global_files:
 post_install_actions:
   - |
     #ddev-nodisplay
+    #ddev-description:Checking docker-compose.cypress_extras.yaml for changes
     if [ -f docker-compose.cypress_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.cypress_extras.yaml; then
       echo "Existing docker-compose.cypress_extras.yaml does not have #ddev-generated, so can't be updated"
       exit 2
     fi
   - |
     #ddev-nodisplay
+    #ddev-description:Adding all hostnames to the cypress container to make them available
     cat <<-END >docker-compose.cypress_extras.yaml
     #ddev-generated
     services:
@@ -39,6 +41,7 @@ post_install_actions:
 removal_actions:
   - |
     #ddev-nodisplay
+    #ddev-description:Remove docker-compose.cypress_extras.yaml file
     if [ -f docker-compose.cypress_extras.yaml ]; then
       if grep -q '#ddev-generated' docker-compose.cypress_extras.yaml; then
         rm -f docker-compose.cypress_extras.yaml

--- a/install.yaml
+++ b/install.yaml
@@ -17,3 +17,32 @@ global_files:
 
 
 post_install_actions:
+  - |
+    #ddev-nodisplay
+    if [ -f docker-compose.cypress_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.cypress_extras.yaml; then
+      echo "Existing docker-compose.cypress_extras.yaml does not have #ddev-generated, so can't be updated"
+      exit 2
+    fi
+  - |
+    #ddev-nodisplay
+    cat <<-END >docker-compose.cypress_extras.yaml
+    #ddev-generated
+    services:
+      cypress:
+        external_links:
+        {{- $cypress_hostnames := splitList "," (env "DDEV_HOSTNAME") -}}
+        {{- range $i, $n := $cypress_hostnames }}
+          - "ddev-router:{{- replace (env "DDEV_TLD") "\\${DDEV_TLD}" (replace (env "DDEV_PROJECT") "\\${DDEV_PROJECT}" $n) -}}"
+        {{- end }}
+    END
+
+removal_actions:
+  - |
+    #ddev-nodisplay
+    if [ -f docker-compose.cypress_extras.yaml ]; then
+      if grep -q '#ddev-generated' docker-compose.cypress_extras.yaml; then
+        rm -f docker-compose.cypress_extras.yaml
+      else
+        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/docker-compose.cypress_extras.yaml' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+      fi
+    fi


### PR DESCRIPTION
## The Issue

From Discord: https://discord.com/channels/664580571770388500/1319240207521939476

`extrernal_links` don't work properly when you have `additional_hostnames` or `additional_fqdns`.

https://github.com/tyler36/ddev-cypress/blob/11d069d3609d5fca7a2e59d51ad65ee2893b5c46/docker-compose.cypress.yaml#L27-L29

```yaml
 external_links: 
   - "ddev-router:${DDEV_HOSTNAME}"
```

It is expanded with an invalid syntax:

```yaml
 external_links: 
   - "ddev-router:primary.ddev.site,secondary.ddev.site"
```

It should look like this:

```yaml
 external_links: 
   - "ddev-router:primary.ddev.site"
   - "ddev-router:secondary.ddev.site"
```

## How This PR Solves The Issue

Uses go templates to create the correct `external_links` in `.ddev/docker-compose.cypress_extras.yaml`

## Manual Testing Instructions

This allows for example to have Mailpit to work automatically without any port change.

```
mkdir cypress-test && cd cypress-test
ddev config --additional-fqdns="hello.test" --additional-hostnames "extra1,extra2,more.extra"
echo '<?php echo "Hello World;"; ?>' > index.php
ddev add-on get https://github.com/stasadev/ddev-cypress/tarball/20241220_stasadev_support_multiple_hostnames

cat .ddev/docker-compose.cypress_extras.yaml
#ddev-generated
services:
  cypress:
    external_links:
      - "ddev-router:${DDEV_PROJECT}.${DDEV_TLD}"
      - "ddev-router:extra1.${DDEV_TLD}"
      - "ddev-router:extra2.${DDEV_TLD}"
      - "ddev-router:hello.test"
      - "ddev-router:more.extra.${DDEV_TLD}"

ddev start

cat .ddev/.ddev-docker-compose-full.yaml
        external_links:
            - ddev-router:cypress-test.ddev.site
            - ddev-router:extra1.ddev.site
            - ddev-router:extra2.ddev.site
            - ddev-router:hello.test
            - ddev-router:more.extra.ddev.site
```

## Related Issue Link(s)

This is really close to this PR:

- https://github.com/ddev/ddev-varnish/pull/25
