### PR TITLE
bump cypress version to `13.17.0`

### DIFF
--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 services:
   cypress:
-    image: cypress/included:13.16.0
+    image: cypress/included:13.17.0
     container_name: ddev-${DDEV_SITENAME}-cypress
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
This PR bumps Cypress to the "latest" version.