### PR TITLE
feat: Addon refresh

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: 🐞 Bug report or Support Request
+description: Create a report to help us improve.
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Preliminary checklist
+      description: Please complete the following checks before submitting an issue.
+      options:
+        - label: I am using the latest stable version of DDEV
+          required: true
+        - label: I am using the latest stable version of this add-on
+          required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Specific steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run `...`
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Screenshots? Anything that will give us more context about your issue!
+
+        💡 Attach images or log files by clicking this area to highlight it and dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: 🚀 Feature request
+description: Suggest an idea for this project.
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search existing issues to see if one already exists for your request.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Clearly and concisely describe the problem. (Ex. I'm always frustrated when...)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe your solution
+      description: Clearly and concisely describe what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives
+      description: Clearly and concisely describe any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## The Issue
+
+- #<issue number>
+
+<!-- Provide a brief description of the issue. -->
+
+## How This PR Solves The Issue
+
+## Manual Testing Instructions
+
+```bash
+ddev add-on get https://github.com/tyler36/ddev-cypress/tarball/<branch>
+ddev restart
+```
+
+## Automated Testing Overview
+
+<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
+
+## Release/Deployment Notes
+
+<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # DDEV-cypress <!-- omit in toc -->
 
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2026.svg)
 - [Introduction](#introduction)
 - [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# DDEV-cypress <!-- omit in toc -->
-
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml)
 [![last commit](https://img.shields.io/github/last-commit/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/commits)
 [![release](https://img.shields.io/github/v/release/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/releases/latest)
+
+# DDEV-cypress <!-- omit in toc -->
 
 - [Introduction](#introduction)
 - [Requirements](#requirements)
@@ -31,6 +31,7 @@ This recipe integrates a Cypress docker image with your DDEV project.
 The main benefit is integration of Chrome and Firefox browsers out of the box, providing a known static state regardless of local OS or cloud CI/CS development. It also provides X11 display support for MacOS and Windows users, whereas this usually just works in Linux.
 
 This addon:
+
 - provides Cypress without the need to install <a href="https://nodejs.org">Node.js</a>
 - provides Firefox and Chromium out of the box, preconfigured for Cypress
 - configures your project's HTTPS site a base URL
@@ -95,6 +96,7 @@ Now __restart your Mac__.  XQuartz will not properly be set to listen for X11 co
 # Run the below command
 xhost + 127.0.0.1
 ```
+
 Add a file called `docker-compose.cypress_extra.yaml` with the following content to the .ddev directory:
 
 ```yaml
@@ -103,6 +105,7 @@ services:
     environment:
       - DISPLAY=host.docker.internal:0
 ```
+
 #### Linux
 
 You may need to set up access control for the X server for this to work. Install the xhost package (one is available for all distros) and run:
@@ -219,4 +222,4 @@ Cypress expects a directory structures containing the tests, plugins and support
 
 - This recipe forwards the Cypress GUI via an X11 / X410 server. Please ensure you have this working on your host system.
 
-**Contributed by [@tyler36](https://github.com/tyler36)**
+__Contributed by [@tyler36](https://github.com/tyler36)__

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # DDEV-cypress <!-- omit in toc -->
 
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
-[![tests](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2026.svg)
+[![tests](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/commits)
+
 - [Introduction](#introduction)
 - [Requirements](#requirements)
 - [Steps](#steps)

--- a/README.md
+++ b/README.md
@@ -49,16 +49,8 @@ Installing Cypress with favorite package manager works great locally. However, m
 
 - Install service
 
-  For DDEV v1.23.5 or above run
-
   ```shell
   ddev add-on get tyler36/ddev-cypress
-  ```
-
-  For earlier versions of DDEV run
-
-  ```shell
-  ddev get tyler36/ddev-cypress
   ```
 
   Then restart the project
@@ -99,7 +91,7 @@ Now __restart your Mac__.  XQuartz will not properly be set to listen for X11 co
 # Run the below command
 xhost + 127.0.0.1
 ```
-Add a file called `docker-compose.cypress_extra.yaml` with the following content to the .ddev directory: 
+Add a file called `docker-compose.cypress_extra.yaml` with the following content to the .ddev directory:
 
 ```yaml
 services:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml)
 [![last commit](https://img.shields.io/github/last-commit/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/releases/latest)
 
 - [Introduction](#introduction)
 - [Requirements](#requirements)

--- a/install.yaml
+++ b/install.yaml
@@ -1,20 +1,21 @@
 name: ddev-cypress
 
+# Available with DDEV v1.23.3+, and works only for DDEV v1.23.3+ binaries
+ddev_version_constraint: '>= v1.24.3'
+
 # pre_install_actions - list of actions to run before installing the addon.
 # Examples would be removing an extraneous docker volume,
 # or doing a sanity check for requirements.
 pre_install_actions:
 
-
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
-- docker-compose.cypress.yaml
-- commands/cypress/cypress-open
-- commands/cypress/cypress-run
+  - docker-compose.cypress.yaml
+  - commands/cypress/cypress-open
+  - commands/cypress/cypress-run
 
 # List of files and directories that are copied into the global .ddev directory
 global_files:
-
 
 post_install_actions:
   - |


### PR DESCRIPTION
## Solution

This PR updates the addon to current practises.
It's mostly related to status badges.
However, it does restrict the addon to DDEV `1.24.3` or above.

## Test

1. Run the following script (draft)

```shell
curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/20250430_stasadev_update_checker/.github/scripts/update-checker.sh | bash
```
